### PR TITLE
Failing tests showing unmock not reverting to original client

### DIFF
--- a/lib/platforms/knex/0.8/client.js
+++ b/lib/platforms/knex/0.8/client.js
@@ -33,7 +33,7 @@ function mockClient(client) {
 
   client.constructor.prototype.processResponse = client.processResponse = function(obj) {
     obj = obj || {};
-    
+
     if (obj.output) {
       obj.result = obj.output.call(this, obj.result);
     } else if (obj.method === 'first') {
@@ -61,7 +61,7 @@ function mockRunner(Runner) {
   });
 }
 
-module.exports = function (db) {
-  mockClient(db.client);
-  mockRunner(db.client.Runner);
+module.exports = function (client) {
+  mockClient(client);
+  mockRunner(client.Runner);
 };

--- a/lib/platforms/knex/0.8/index.js
+++ b/lib/platforms/knex/0.8/index.js
@@ -6,7 +6,7 @@ module.exports = {
       db._oldClient = db.client;
     }
 
-    makeClient(db);
+    makeClient(db.client);
   },
 
   unmock: function unmock(db) {

--- a/test/tracker.spec.js
+++ b/test/tracker.spec.js
@@ -51,13 +51,18 @@ describe('Mock DB : ', function mockKnexTests() {
         }
       });
 
+      expect(db.client.driverName).to.equal('sqlite3');
+
       mod.mock(db);
 
+      expect(db.client.driverName).to.equal('mocked');
       expect(db._oldClient).to.be.a('object');
+      expect(db._oldClient.driverName).to.equal('sqlite3');
 
       mod.unmock(db);
 
       expect(db._oldClient).to.be.undefined;
+      expect(db.client.driverName).to.equal('sqlite3');
 
       done();
     });


### PR DESCRIPTION
I ran into an issue where 1 of my tests was failing that was expecting the actual database and not the mock (but ran after the tests using a mock).  After digging around, I found that `mockDb.unmock(knex)` was not restoring the original `knex.client` correctly.  The issue is due to [this line](https://github.com/colonyamerican/mock-knex/blob/master/lib/platforms/knex/0.8/index.js#L6) where it is expected that `db._oldClient` is a clone of `db.client` but it is instead just another reference to the same object and those getting mocked directly.

I attempted to use lodash's shallow copy `_.clone(...)` to fix the issue by shallow cloning `db.client` and `db.client.Runner` like so...

```js
  mock: function mockDatabase(db) {
    if (! db._oldClient) {
      db._oldClient = db.client;
    }

    db.client = _.clone(db.client);
    db.client.Runner = _.clone(db.client.Runner);

    makeClient(db.client);
  },
```

...but doing so just causes the `should revert a single adapter back to the original` test to hang on `mod.mock(db)` and I'm struggling to understand why.  I'm not sure if it would be better to instead restore all the patched functions in `client.js` (`client.acquireConnection`, `client.releaseConnection`, `client.prototype._query`, etc).