### PR TITLE
Knex 0.9 support

### DIFF
--- a/lib/platforms/knex/0.9/client.js
+++ b/lib/platforms/knex/0.9/client.js
@@ -1,0 +1,67 @@
+'use strict';
+
+var Promise = require('bluebird');
+var _ = require('lodash');
+var tracker = require('../../../tracker');
+
+var connection = {
+  id : 'mockedConnection',
+};
+
+function mockClient(client) {
+  client.driverName = 'mocked';
+
+  client.acquireConnection = Promise.method(function() {
+    return connection;
+  });
+
+  client.releaseConnection = Promise.method(_.noop);
+
+  client.acquireRawConnection = Promise.method(function() {
+    return {};
+  });
+
+  client.destroyRawConnection = function destroyRawConnection(connection, cb) {
+    cb();
+  };
+
+  client.constructor.prototype._query = client._query = function(connection, obj) {
+    return new Promise(function(resolver, rejecter) {
+      tracker.queries.track(obj, resolver);
+    });
+  };
+
+  client.constructor.prototype.processResponse = client.processResponse = function(obj) {
+    obj = obj || {};
+    
+    if (obj.output) {
+      obj.result = obj.output.call(this, obj.result);
+    } else if (obj.method === 'first') {
+      obj.result = Array.isArray(obj.result) ? obj.result[0] : obj.result;
+    } else if (obj.method === 'pluck') {
+      obj.result = _.pluck(obj.result, obj.pluck);
+    }
+
+    return obj.result;
+  };
+}
+
+function mockRunner(Runner) {
+  Runner.prototype = _.omit(Runner.prototype, 'connection');
+
+  Runner.prototype.ensureConnection = function() {
+    return Promise.resolve(this.connection || {});
+  };
+
+  Object.defineProperty(Runner.prototype, "connection", {
+    get : function () {
+      return connection;
+    },
+    set : function (val) {}
+  });
+}
+
+module.exports = function (db) {
+  mockClient(db.client);
+  mockRunner(db.client.Runner);
+};

--- a/lib/platforms/knex/0.9/index.js
+++ b/lib/platforms/knex/0.9/index.js
@@ -1,0 +1,16 @@
+var makeClient = require('./client');
+
+module.exports = {
+  mock: function mockDatabase(db) {
+    if (! db._oldClient) {
+      db._oldClient = db.client;
+    }
+
+    makeClient(db);
+  },
+
+  unmock: function unmock(db) {
+    db.client = db._oldClient;
+    delete db._oldClient;
+  },
+};

--- a/lib/platforms/knex/0.9/knex.js
+++ b/lib/platforms/knex/0.9/knex.js
@@ -1,0 +1,38 @@
+'use strict';
+
+var Promise = require('bluebird');
+var _ = require('lodash');
+var tracker = require('../../../tracker');
+
+module.exports = function (client) {
+  var Runner = client.Runner;
+
+  client.driverName = 'mocked';
+  client.initDriver = client.initPool = client.initMigrator = _.noop;
+
+  client.acquireRawConnection = Promise.method(function() {
+    return {};
+  });
+
+  client.destroyRawConnection = function destroyRawConnection(connection, cb) {
+    cb();
+  };
+
+  client._query = function(connection, obj) {
+    return new Promise(function(resolver, rejecter) {
+      tracker.queries.track(obj, resolver);
+    });
+  };
+
+  client.processResponse = function(obj) {
+    if (obj.output) {
+      obj.result = obj.output.call(this, obj.result);
+    } else if (obj.method === 'first') {
+      obj.result = Array.isArray(obj.result) ? obj.result[0] : obj.result;
+    } else if (obj.method === 'pluck') {
+      obj.result = _.pluck(obj.result, obj.pluck);
+    }
+
+    return obj.result;
+  };
+};

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "sqlite3": "^3.0.8"
   },
   "peerDependencies": {
-    "knex": "^0.7.0 || ^0.8.0"
+    "knex": "^0.7.0 || ^0.8.0 || ^0.9.0"
   },
   "dependencies": {
     "bluebird": "^2.9.25",

--- a/test/tracker.spec.js
+++ b/test/tracker.spec.js
@@ -42,7 +42,7 @@ describe('Mock DB : ', function mockKnexTests() {
     });
 
     it('should revert a single adapter back to the original', function revertSingle(done) {
-      var db = knex({
+      db = knex({
         dialect: 'sqlite3',
         connection: {
           filename: './data.db'


### PR DESCRIPTION
### Change summary

* Reusing the 0.8 knex client for 0.9, since the [knex site](http://knexjs.org/#Upgrading-from0.8) indicates that upgrading doesn't require clients do anything.
* Miscellaneous fix in the test suite.
* Add `knex 0.9` as a supported `peerDependency`.

### Issues: 

I did notice the same leak reported by the test runner, before and after this change:

> `The following leaks were detected:Intl, Set, Map`

Otherwise, all the tests passed.