### PR TITLE
Fix unmocking functionality on knex 0.10.0

### DIFF
--- a/lib/platforms/knex/0.10/client.js
+++ b/lib/platforms/knex/0.10/client.js
@@ -3,37 +3,39 @@
 var Promise = require('bluebird');
 var _ = require('lodash');
 var tracker = require('../../../tracker');
+var mock = require('../../../../util/mock');
+var originalDriverName;
 
 var connection = {
   id : 'mockedConnection',
 };
 
-function mockClient(client) {
-  client.driverName = 'mocked';
-
-  client.acquireConnection = Promise.method(function() {
+var clientMocks = {
+  acquireConnection: function () {
     return connection;
-  });
+  },
 
-  client.releaseConnection = Promise.method(_.noop);
+  releaseConnection: Promise.method(_.noop),
 
-  client.acquireRawConnection = Promise.method(function() {
+  acquireRawConnection: Promise.method(function() {
     return {};
-  });
+  }),
 
-  client.destroyRawConnection = function destroyRawConnection(connection, cb) {
+  destroyRawConnection: function destroyRawConnection(connection, cb) {
     cb();
-  };
+  },
+};
 
-  client.constructor.prototype._query = client._query = function(connection, obj) {
-    return new Promise(function(resolver, rejecter) {
+var clientPrototypeMocks = {
+  _query: function (connection, obj) {
+    return new Promise(function (resolver, rejecter) {
       tracker.queries.track(obj, resolver);
     });
-  };
+  },
 
-  client.constructor.prototype.processResponse = client.processResponse = function(obj) {
+  processResponse: function (obj) {
     obj = obj || {};
-    
+
     if (obj.output) {
       obj.result = obj.output.call(this, obj.result);
     } else if (obj.method === 'first') {
@@ -43,25 +45,70 @@ function mockClient(client) {
     }
 
     return obj.result;
-  };
-}
+  },
+};
 
-function mockRunner(Runner) {
-  Runner.prototype = _.omit(Runner.prototype, 'connection');
+function mockClient(client) {
+  originalDriverName = client.driverName;
+  client.driverName = 'mocked';
 
-  Runner.prototype.ensureConnection = function() {
-    return Promise.resolve(this.connection || {});
-  };
+  Object.keys(clientMocks).map(function(key) {
+    mock.mockProperty(client, key, clientMocks[key]);
+  });
 
-  Object.defineProperty(Runner.prototype, "connection", {
-    get : function () {
-      return connection;
-    },
-    set : function (val) {}
+  Object.keys(clientPrototypeMocks).map(function(key) {
+    mock.mockPrototype(client, key, clientPrototypeMocks[key]);
   });
 }
 
-module.exports = function (db) {
-  mockClient(db.client);
-  mockRunner(db.client.Runner);
+function unmockClient(client) {
+  client.driverName = originalDriverName;
+
+  Object.keys(clientMocks)
+    .concat(Object.keys(clientPrototypeMocks))
+    .map(function(key) {
+      client[key].restore();
+    });
+}
+
+function mockRunner(Runner) {
+  var mockedRunner = Runner.prototype;
+
+  var newRunner = {};
+
+  Object.getOwnPropertyNames(mockedRunner).map(function(key) {
+    if(['ensureConnection', 'connection'].indexOf(key) === -1) {
+      newRunner[key] = mockedRunner[key];
+    }
+  });
+
+  newRunner.ensureConnection = function() {
+    return Promise.resolve(this.connection || {});
+  };
+
+  Object.defineProperty(newRunner, "connection", {
+    get : function () {
+      return connection;
+    },
+    set : function () {}
+  });
+
+  newRunner.restore = function() {
+    Runner.prototype = mockedRunner;
+  }
+
+  Runner.prototype = newRunner;
+}
+
+module.exports = {
+  mock: function(db) {
+    mockClient(db.client);
+    mockRunner(db.client.Runner);
+  },
+  unmock: function(db) {
+    unmockClient(db.client);
+    db.client.Runner.prototype.restore();
+  },
 };
+
+

--- a/lib/platforms/knex/0.10/index.js
+++ b/lib/platforms/knex/0.10/index.js
@@ -1,16 +1,11 @@
-var makeClient = require('./client');
+var client = require('./client');
 
 module.exports = {
   mock: function mockDatabase(db) {
-    if (! db._oldClient) {
-      db._oldClient = db.client;
-    }
-
-    makeClient(db);
+    client.mock(db);
   },
 
   unmock: function unmock(db) {
-    db.client = db._oldClient;
-    delete db._oldClient;
+    client.unmock(db);
   },
 };

--- a/test/tracker.spec.js
+++ b/test/tracker.spec.js
@@ -52,11 +52,11 @@ describe('Mock DB : ', function mockKnexTests() {
 
       mod.mock(db);
 
-      expect(db._oldClient).to.be.a('object');
+      expect(db.client.driverName).to.equal('mocked');
 
       mod.unmock(db);
 
-      expect(db._oldClient).to.be.undefined;
+      expect(db.client.driverName).to.equal('sqlite3');
 
       done();
     });

--- a/util/mock.js
+++ b/util/mock.js
@@ -1,0 +1,25 @@
+function mockProperty(object, property, method) {
+  var mockedProperty = object[property];
+  object[property] = method;
+
+  method.restore = function () {
+    object[property] = mockedProperty;
+  }
+}
+
+function mockPrototype(object, property, method) {
+  var mockedProperty = object[property];
+  var mockedPrototype = object.constructor.prototype[property];
+
+  object.constructor.prototype[property] = object[property] = method;
+
+  method.restore = function () {
+    object[property] = mockedProperty;
+    object.constructor.prototype[property] = mockedPrototype;
+  }
+}
+
+module.exports = {
+  mockProperty: mockProperty,
+  mockPrototype: mockPrototype,
+}


### PR DESCRIPTION
The code as-is doesn't unmock because it is still using the old object's references. Here's my humble fix, via mocking the `knex` properties on the objects and making a prop-by-prop copy where needed. This is not the prettiest mocking code but it gets the job done. PR also removes the `leak` warnings on tests for knex 0.10.