### PR TITLE
Update readme to mention support of latest Knex

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ with [fixture-factory](http://github.com/colonyamerican/fixture-factory).
 
 ## Knex Support
 
-Currently supports knex 0.8 through 0.12
+Currently supports knex 0.8 through 0.13.
 
 ## Installation
 


### PR DESCRIPTION
I noticed that Knex 0.13 support was added with `mock-knex@0.3.9`, but it isn't mentioned at all in the Readme file. This is a very small update to mention it.